### PR TITLE
Angle integration

### DIFF
--- a/src/tests/data_processing/test_azimuthal_integration.py
+++ b/src/tests/data_processing/test_azimuthal_integration.py
@@ -198,6 +198,7 @@ class TestAzimuthalIntegration(unittest.TestCase):
                 "calculated_distance": 0.1,
                 "pixel_size": 100,
                 "interpolation_q_range": (0, 5),
+                "azimuthal_range": (-180, 180),
             }
         )
 
@@ -207,7 +208,11 @@ class TestAzimuthalIntegration(unittest.TestCase):
 
         mock_initialize_ai_df.assert_called_once()
         mock_ai.integrate1d.assert_called_once_with(
-            row["measurement_data"], 256, radial_range=(0, 5), mask=mask
+            row["measurement_data"],
+            256,
+            radial_range=(0, 5),
+            azimuth_range=(-180, 180),
+            mask=mask,
         )
         np.testing.assert_array_equal(radial, np.array([1, 2, 3]))
         np.testing.assert_array_equal(intensity, np.array([4, 5, 6]))
@@ -246,7 +251,11 @@ class TestAzimuthalIntegration(unittest.TestCase):
 
         mock_initialize_ai_df.assert_called_once()
         mock_ai.integrate1d.assert_called_once_with(
-            row["measurement_data"], 256, radial_range=None, mask=None
+            row["measurement_data"],
+            256,
+            radial_range=None,
+            azimuth_range=None,
+            mask=None,
         )
         np.testing.assert_array_equal(radial, np.array([1, 2, 3]))
         np.testing.assert_array_equal(intensity, np.array([4, 5, 6]))

--- a/src/xrdanalysis/data_processing/azimuthal_integration.py
+++ b/src/xrdanalysis/data_processing/azimuthal_integration.py
@@ -85,6 +85,9 @@ def perform_azimuthal_integration(
                 interpolation, where q is the momentum transfer,
                 in reciprocal nanometers. If not provided, the
                 full q range will be used.
+            - 'azimuthal_range' (tuple or None, optional): A tuple
+                (min_deg, max_deg) specifying the range of degrees for
+                integration, degrees are in a range from -Pi to Pi.
             OR
             - 'calibration_measurement_id' (int): Integer associated with the
                 id of specific calibration, used to name the poni file.
@@ -96,6 +99,9 @@ def perform_azimuthal_integration(
                 for interpolation, where q is the momentum transfer,
                 in reciprocal nanometers. If not provided, the full
                 q range will be used.
+             - 'azimuthal_range' (tuple or None, optional): A tuple
+                (min_deg, max_deg) specifying the range of degrees for
+                integration, degrees are in a range from -Pi to Pi.
         npt (int, optional): Number of points for integration. Defaults to 256.
         mask (array_like, optional): Mask array to be applied during
             integration, 1-s are for pixels to be masked, 0-s for pixels
@@ -119,6 +125,7 @@ def perform_azimuthal_integration(
     """
 
     interpolation_q_range = row.get("interpolation_q_range")
+    azimuthal_range = row.get("azimuthal_range")
     data = row["measurement_data"]
 
     if calibration_mode == "dataframe":
@@ -143,11 +150,19 @@ def perform_azimuthal_integration(
 
     if mode == "1D":
         radial, intensity = ai_cached.integrate1d(
-            data, npt, radial_range=interpolation_q_range, mask=mask
+            data,
+            npt,
+            radial_range=interpolation_q_range,
+            azimuth_range=azimuthal_range,
+            mask=mask,
         )
         return radial, intensity, ai_cached.dist
     elif mode == "2D":
         intensity, radial, azimuthal = ai_cached.integrate2d(
-            data, npt, radial_range=interpolation_q_range, mask=mask
+            data,
+            npt,
+            radial_range=interpolation_q_range,
+            azimuth_range=azimuthal_range,
+            mask=mask,
         )
         return radial, intensity, azimuthal, ai_cached.dist

--- a/src/xrdanalysis/data_processing/azimuthal_integration.py
+++ b/src/xrdanalysis/data_processing/azimuthal_integration.py
@@ -101,7 +101,7 @@ def perform_azimuthal_integration(
                 q range will be used.
              - 'azimuthal_range' (tuple or None, optional): A tuple
                 (min_deg, max_deg) specifying the range of degrees for
-                integration, degrees are in a range from -Pi to Pi.
+                integration, degrees are in a range from -180 to 180. 
         npt (int, optional): Number of points for integration. Defaults to 256.
         mask (array_like, optional): Mask array to be applied during
             integration, 1-s are for pixels to be masked, 0-s for pixels


### PR DESCRIPTION
Added integration over angle to azimuthal integrator. Now integration can be used over a sector of an image instead of full image. The logic is the same as with interpolation_q_range, the angles are in degrees from -180 to 180.